### PR TITLE
fix(js): Ensure that ploneintranet.js loads early

### DIFF
--- a/src/ploneintranet/theme/profiles/default/jsregistry.xml
+++ b/src/ploneintranet/theme/profiles/default/jsregistry.xml
@@ -2,5 +2,6 @@
 <object name="portal_javascripts" meta_type="JavaScripts Registry">
  <javascript authenticated="False" cacheable="True" compression="safe"
     conditionalcomment="" cookable="True" enabled="True" expression=""
+    insert-after="++resource++plone.app.jquery.js"
     id="++theme++ploneintranet.theme/generated/bundles/ploneintranet.js" inline="False"/>
 </object>


### PR DESCRIPTION
ploneintranet.js overrides jquery during load time
...
1. plone.app.jquerytools instructs jQuery to load some
2. code after loading, and passes in the current jQuery
   to that code
3. Page loaded
4. plone.app.jqueryTools registers prepOverlay with
   jQuery available in 1.
5. Simplesocial uses jQuery.prepOverlay()

Without this change, jQuery gets overriden between 2 and 3.
in 4, prepOverlay gets installed in old jQuery
in 5, prepOverlay is looked up in new jQuery

With this Change, jQuery gets overriden before 1.
