### PR TITLE
Fix broken post form

### DIFF
--- a/src/ploneintranet/theme/browser/templates/dashboard.pt
+++ b/src/ploneintranet/theme/browser/templates/dashboard.pt
@@ -22,7 +22,7 @@
                     </div>
                 </div>
                 <div class="eight columns">
-                    <div id="new-post-box" data-tile="./@@newpostbox.tile"></div>
+                    <form id="new-post-box" class="pat-inject update-social status-inactive" action="/feedback/post-well-done.html" data-pat-inject="source: #activity-stream; target: #activity-stream::before &amp;&amp; #new-post-box" data-tile="./@@newpostbox.tile"></form>
                     <div id="activity-stream" data-tile="./@@activitystream.tile?network=1"></div>
                 </div>
             </div>

--- a/src/ploneintranet/theme/browser/templates/new-post-box-tile.pt
+++ b/src/ploneintranet/theme/browser/templates/new-post-box-tile.pt
@@ -1,6 +1,5 @@
 <html>
     <body>
-        <form id="new-post-box" class="pat-inject update-social status-inactive" action="/feedback/post-well-done.html" data-pat-inject="source: #activity-stream; target: #activity-stream::before &amp;&amp; #new-post-box">
             <fieldset>
                 <p class="content-mirror"><span class="text"><em class="placeholder">Leave a comment</em></span><em class="selected-users" id="selected-users"></em><em class="selected-tags" id="selected-tags"></em></p>
                 <textarea placeholder="Leave a comment" class="pat-content-mirror pat-switch" data-pat-switch="#new-post-box status-inactive status-active"></textarea>
@@ -43,6 +42,5 @@
                     </label>
                 </div>
             </fieldset>
-        </form>
     </body>
 </html>


### PR DESCRIPTION
The canonical way to include a tile is <div data-tile="tilename" />. Then the content of the tile is added as child of the div tag. It works like tal:content. This has led to a superfluous div tag (which we must avoid to not get styling issues) plus a duplicate id="new-post-box" which was fatal for the pat-switch to work.

As far as I see it, there is no way to tell plone.tiles to do the equivalent of a tal:replace, which would have solved that, instead we must move the form tag into the dashboard and remove it from the tile template. 

On second thought, this is somewhat wise because it avoids introduction of placeholder tags like divs or span which have no real meaning anyway.