### PR TITLE
Content of the source page now shows on missing design page

### DIFF
--- a/prototype/empty.html
+++ b/prototype/empty.html
@@ -14,3 +14,7 @@ content which is not yet reflected in the diazo ruleset. </p>
 
 <p>You might need to set up a rule that assigns the correct design template for this type of content.</p>
 
+<p>Below is <strong>a glimpse of the content that is in the #content selector</strong> of the source page. Most likely it is misformatted, and it is only shown here to give you an idea what that page is about so that you can <strong>make sure to get it styled</strong>.</p>
+<hr>
+
+	<div id="original-content" />

--- a/src/ploneintranet/theme/static/rules.xml
+++ b/src/ploneintranet/theme/static/rules.xml
@@ -109,6 +109,7 @@
 
 <rules css:if-content="#visual-portal-wrapper">
   <theme href="generated/empty.html" />
+  <replace css:content-children="#content" css:theme-children="#original-content" />
 </rules>
 
 <notheme css:if-content="body.diazo-off"/>


### PR DESCRIPTION
Include the content of the source page on the missing design page when no styling exists yet so that a dev does not have to enable diazo.off=1 explicitly