### PR TITLE
Remove events from workspace document listing in sidebar

### DIFF
--- a/prototype/_includes/item-selector.html
+++ b/prototype/_includes/item-selector.html
@@ -64,7 +64,7 @@
                                     name="batch-function"
                                     value="cut"
                                     class="float-before icon-cut no-label pat-depends"
-                                    data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'event' or doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
+                                    data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
                                     formaction="/feedback/banner-notifications#documents-cut"
                                     title="Cut">Cut</button>
                             <button type="submit"
@@ -72,7 +72,7 @@
                                     value="copy"
                                     formaction="/feedback/banner-notifications#documents-copied"
                                     class="float-before icon-copy no-label pat-depends"
-                                    data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'event' or doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
+                                    data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
                                     title="Copy">Copy</button>
                             <button disabled
                                     type="submit"
@@ -88,27 +88,27 @@
                                 name="batch-function"
                                 value="delete"
                                 class="float-before icon-trash no-label pat-depends"
-                                data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'event' or doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
+                                data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
                                 title="Delete">Delete</button>
                         <button type="submit"
                                 name="batch-function"
                                 value="rename"
                                 formaction="/feedback/batch-rename.html#content"
                                 class="float-before icon-rename no-label pat-depends"
-                                data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'event' or doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
+                                data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
                                 title="Rename">Rename</button>
                         <button formaction="/feedback/batch-tag.html#content"
                                 type="submit"
                                 name="batch-function"
                                 value="tag"
                                 class="float-before icon-tags no-label pat-depends"
-                                data-pat-depends="condition:false {% for doc in site.posts %}{% if (doc.parent == include.title) and (doc.layout == 'event' or doc.layout ==  'news' or doc.layout == 'document' or doc.layout == 'folder') %}{% if doc.folderish != true %}or {% endif %}{% if doc.folderish == true %}and (not {% endif %}{{ doc.id | remove: '/' }} {% if doc.folderish == true %}) {% endif %}{% endif %}{% endfor %}; action: enable;"
+                                data-pat-depends="condition:false {% for doc in site.posts %}{% if (doc.parent == include.title) and (doc.layout ==  'news' or doc.layout == 'document' or doc.layout == 'folder') %}{% if doc.folderish != true %}or {% endif %}{% if doc.folderish == true %}and (not {% endif %}{{ doc.id | remove: '/' }} {% if doc.folderish == true %}) {% endif %}{% endif %}{% endfor %}; action: enable;"
                                 title="Re-tag">Re-tag</button>
                         <button type="submit"
                                 name="batch-function"
                                 value="tag"
                                 class="float-before icon-export pat-depends"
-                                data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout == 'event' or doc.layout ==  'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
+                                data-pat-depends="condition:{% for doc in site.posts %}{% if doc.parent == include.title and (doc.layout ==  'news' or doc.layout == 'document' or doc.layout == 'folder') %}{{ doc.id | remove: '/' }} or {% endif %}{% endfor %} false; action: enable"
                                 title="Share">Share</button>
                     </div>
                 </div>
@@ -159,7 +159,7 @@
             {% elsif include.mode == "docs" %}
 
                 {% for doc in site.posts %}
-                    {% if doc.parent == include.title and (doc.layout == 'event' or doc.layout ==  'news' or doc.layout == 'document'  or doc.layout == 'folder') %}
+                    {% if doc.parent == include.title and (doc.layout == 'news' or doc.layout == 'document'  or doc.layout == 'folder') %}
                         {% if doc.folderish == false %}
                             <!-- Each document has a class name on the label element that indicates the document type.
 


### PR DESCRIPTION
This should resolve issue #67 

Only items with front-matter layout of news, doc or folder will appear in the document sidebar.

@cornae I think you are probably best suited to review and merge this.

