### PR TITLE
Experimental main template

### DIFF
--- a/src/ploneintranet/theme/browser/configure.zcml
+++ b/src/ploneintranet/theme/browser/configure.zcml
@@ -7,7 +7,16 @@
     xmlns:z3c="http://namespaces.zope.org/z3c"
     i18n_domain="ploneintranet.theme">
 
-  <!-- BEGIN Example views (used to document and show patterns usage) -->
+  <!-- Simplified main_template -->
+  <browser:page
+    for="*"
+    name="main_template"
+    class=".main_template.PIMainTemplate"
+    permission="zope.Public"
+    layer="..interfaces.IThemeSpecific"
+  />
+
+<!-- BEGIN Example views (used to document and show patterns usage) -->
   <browser:page
       name="dnd-upload-example"
       for="Products.CMFCore.interfaces.IFolderish"

--- a/src/ploneintranet/theme/browser/main_template.py
+++ b/src/ploneintranet/theme/browser/main_template.py
@@ -1,0 +1,7 @@
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.CMFPlone.browser.main_template import MainTemplate
+
+
+class PIMainTemplate(MainTemplate):
+    main_template = ViewPageTemplateFile('templates/main_template.pt')
+

--- a/src/ploneintranet/theme/browser/templates/main_template.pt
+++ b/src/ploneintranet/theme/browser/templates/main_template.pt
@@ -1,0 +1,129 @@
+<metal:page define-macro="master">
+<tal:doctype tal:replace="structure string:&lt;!DOCTYPE html&gt;" />
+
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:define="portal_state context/@@plone_portal_state;
+          context_state context/@@plone_context_state;
+          plone_view context/@@plone;
+          plone_layout context/@@plone_layout;
+          lang portal_state/language;
+          view nocall:view | nocall: plone_view;
+          dummy python: plone_layout.mark_view(view);
+          portal_url portal_state/portal_url;
+          checkPermission nocall: context/portal_membership/checkPermission;
+          site_properties context/portal_properties/site_properties;
+          ajax_include_head request/ajax_include_head | nothing;
+          ajax_load python:False;
+          toolbar_class python:request.cookies.get('plone-toolbar', 'plone-toolbar-left pat-toolbar')"
+      tal:attributes="lang lang;">
+
+    <metal:cache tal:replace="structure provider:plone.httpheaders" />
+
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+
+    <div tal:replace="structure provider:plone.htmlhead" />
+    <link tal:replace="structure provider:plone.htmlhead.links" />
+
+    <tal:comment replace="nothing">
+        Various slots where you can insert elements in the header from a template.
+    </tal:comment>
+    <metal:topslot define-slot="top_slot" />
+    <metal:headslot define-slot="head_slot" />
+    <metal:styleslot define-slot="style_slot" />
+
+    <div tal:replace="structure provider:plone.scripts" />
+    <metal:javascriptslot define-slot="javascript_head_slot" />
+
+    <meta name="generator" content="Plone - http://plone.org" />
+
+  </head>
+
+  <body tal:define="isRTL portal_state/is_rtl;
+                    body_class python:plone_layout.bodyClass(template, view);"
+        tal:attributes="class body_class;
+                        dir python:isRTL and 'rtl' or 'ltr';
+                        python:plone_view.patterns_settings()"
+        id="visual-portal-wrapper">
+
+    <header id="portal-top" i18n:domain="plone">
+      <div tal:replace="structure provider:plone.portaltop" />
+    </header>
+
+    <div id="portal-mainnavigation" tal:content="structure provider:plone.mainnavigation">
+      The main navigation
+    </div>
+
+    <aside id="global_statusmessage">
+      <tal:message tal:content="structure provider:plone.globalstatusmessage"/>
+      <div metal:define-slot="global_statusmessage">
+      </div>
+    </aside>
+
+    <section id="viewlet-above-content" tal:content="structure provider:plone.abovecontent" />
+
+    <article id="portal-column-content">
+
+      <metal:block define-slot="content">
+
+      <div metal:define-macro="content">
+
+
+        <metal:slot define-slot="body">
+
+        <article id="content">
+
+          <metal:bodytext define-slot="main">
+
+          <header>
+            <div id="viewlet-above-content-title" tal:content="structure provider:plone.abovecontenttitle" />
+            <metal:title define-slot="content-title">
+                <h1 class="documentFirstHeading"
+                    tal:define="title context/Title"
+                    tal:condition="title"
+                    tal:content="title">Title or id</h1>
+            </metal:title>
+            <div id="viewlet-below-content-title" tal:content="structure provider:plone.belowcontenttitle" />
+
+            <metal:description define-slot="content-description">
+                <div class="documentDescription description"
+                     tal:define="description context/Description"
+                     tal:content="description"
+                     tal:condition="description">
+                    Description
+                </div>
+            </metal:description>
+          </header>
+
+          <section id="viewlet-above-content-body" tal:content="structure provider:plone.abovecontentbody" />
+          <section id="content-core">
+            <metal:text define-slot="content-core" tal:content="nothing">
+              Page body text
+            </metal:text>
+          </section>
+          <section id="viewlet-below-content-body" tal:content="structure provider:plone.belowcontentbody" />
+
+          </metal:bodytext>
+        </article>
+
+        </metal:slot>
+
+<!--                 <metal:sub define-slot="sub" tal:content="nothing">
+                   This slot is here for backwards compatibility only.
+                   Don't use it in your custom templates.
+                </metal:sub> -->
+      </div>
+
+      </metal:block>
+      <footer>
+        <div id="viewlet-below-content" tal:content="structure provider:plone.belowcontent" />
+      </footer>
+    </article>
+
+  </body>
+</html>
+
+</metal:page>


### PR DESCRIPTION
This is a custom main template which drops edit bar and portlet slots as we will not reuse them. This does not affect the barceloneta theme, so we can still do theme switching if we need the Plone UI. Refs 4213 and 4214