### PR TITLE
Remove attibutes in the tile placeholder element

### DIFF
--- a/src/ploneintranet/theme/browser/templates/dashboard.pt
+++ b/src/ploneintranet/theme/browser/templates/dashboard.pt
@@ -22,8 +22,8 @@
                     </div>
                 </div>
                 <div class="eight columns">
-                    <form id="new-post-box" class="pat-inject update-social status-inactive" action="@@stream" data-pat-inject="source: #activity-stream; target: #activity-stream::before &amp;&amp; #new-post-box" data-tile="./@@newpostbox.tile" tal:attributes="action string:${portal_url}/@@stream"></form>
-                    <div id="activity-stream" data-tile="./@@activitystream.tile?network=1"></div>
+                    <form data-tile="./@@newpostbox.tile"></form>
+                    <div data-tile="./@@activitystream.tile?network=1"></div>
                 </div>
             </div>
 


### PR DESCRIPTION
The element that contains the tile, in our buildout that uses the branch mosaic-sprint of plone.app.block , will be replaced.
So it is pointless to define attributes in that element other than data-tile.

I would like to remove does attribute to not confuse people (and myself ;) )