### PR TITLE
Fix comment injection on status posts

### DIFF
--- a/prototype/_includes/post.html
+++ b/prototype/_includes/post.html
@@ -61,7 +61,7 @@
 		</section>
 	{% endif %}
 	<div class="functions">
-		
+
 		<!-- Buttons and anchors in this section get a class 'active, when the share or like is used by the current user.' -->
 		<a href="/sharing.html#document-content" class="share pat-modal">Share <sup class="counter">({{ item.shares }})</sup></a>
 		<form action="/feedback/liked.html#content" class="pat-inject pat-autosubmit" id="functions-{{mypostUID}}" data-pat-inject="source: #functions; target: #functions-{{mypostUID}}">
@@ -70,13 +70,13 @@
 		</form>
 	</div>
 	<div class="comments">
-		
+
 		<div id="comment-trail-{{mypostUID}}">
 			{% for comment in item.comments %}
 				{% include comment.html %}
 			{% endfor %}
 		</div>
-		{% capture localtarget %}#comment-trail-{{mypostUID}}{% endcapture %}
+		{% capture localtarget %}#comment-trail-{{mypostUID}}::before{% endcapture %}
 		{% include update-social.html id=mypostUID visibility="false" action="/feedback/comment-well-said.html#comment-trail" %}
 	</div>
 </div>


### PR DESCRIPTION
In the current proto, if you reply to a post that already has a comment, then the existing comment is replaced by injection with the new one.
(See "Jeff Peters: I would like to share this presentation...." and the reply "Adrian White: Hear hear!") 

I think we need to add ::before to the target of the injection for a comment on a status post.
That will cause the new comment to be added on top of the existing comments instead.
