### PR TITLE
Modal mask transparancy

### DIFF
--- a/prototype/_sass/libraries/patterns/components/_modal.scss
+++ b/prototype/_sass/libraries/patterns/components/_modal.scss
@@ -103,9 +103,9 @@ div.pat-modal {
     z-index: 2;
     border: 1px #dedede solid;
     box-shadow: 0 0.1em 0.4em rgba(0,0,0,0.2);
-    -moz-pointer-events:none;  
-    -webkkt-pointer-events:none;  
-    pointer-events:none;  
+    -moz-pointer-events:none;
+    -webkkt-pointer-events:none;
+    pointer-events:none;
   }
 
   .wizard-box {

--- a/prototype/_sass/libraries/patterns/components/_modal.scss
+++ b/prototype/_sass/libraries/patterns/components/_modal.scss
@@ -160,7 +160,7 @@ div.pat-modal {
     left: -10000px;
     background-color: rgba(255,255,255,0.98);
     z-index: -1;
-    opacity: 0;
+    opacity: 0.98;
 
     -moz-animation: fadeIn 1s;
     -webkit-animation: fadeIn 1s;

--- a/prototype/_sass/libraries/patterns/components/_modal.scss
+++ b/prototype/_sass/libraries/patterns/components/_modal.scss
@@ -104,7 +104,7 @@ div.pat-modal {
     border: 1px #dedede solid;
     box-shadow: 0 0.1em 0.4em rgba(0,0,0,0.2);
     -moz-pointer-events:none;
-    -webkkt-pointer-events:none;
+    -webkit-pointer-events:none;
     pointer-events:none;
   }
 


### PR DESCRIPTION
In Firefox, IE and Safari the modal mask (e.g. for login box)which should obscure the rest of the page is transparent.
![screen shot 2015-03-04 at 10 54 05](https://cloud.githubusercontent.com/assets/1485452/6482394/531d122c-c25d-11e4-8872-38f2c103bc2a.png)

This PR resolves this issue for FF and IE and partially for Safari.
Unfortunately the page <header>  in Safari still is not obscured:
![screen shot 2015-03-04 at 10 55 28](https://cloud.githubusercontent.com/assets/1485452/6482410/7e84a89e-c25d-11e4-8138-87d89fa5d96b.png)

