### PR TITLE
reduce z-index for modal mask so users can interact with modal contents in IE

### DIFF
--- a/prototype/_sass/libraries/patterns/components/_modal.scss
+++ b/prototype/_sass/libraries/patterns/components/_modal.scss
@@ -100,7 +100,7 @@ div.pat-modal {
     bottom: -1px;
     content: " ";
     display: block;
-    z-index: 2;
+    z-index: 1;
     border: 1px #dedede solid;
     box-shadow: 0 0.1em 0.4em rgba(0,0,0,0.2);
     -moz-pointer-events:none;


### PR DESCRIPTION
@fulv another simple one here. 
In certain circumstances the fix exposes another issue with pat-modal miscalculating modal height but that should be resolved in the pattern not hidden in css.

Waffle:
closes #108 