### PR TITLE
Move height off logo img to parent #site-logo

### DIFF
--- a/prototype/_sass/components/_logo.scss
+++ b/prototype/_sass/components/_logo.scss
@@ -7,14 +7,15 @@
 .logo#site-logo {
 	float: left;
 	margin-right: 14px;
-	
+	height: 19px;
+
 	@include screen-size(small) {
 		display: none;
 	}
 }
 
 .logo#site-logo img {
-	height: 19px;
+	height: 100%;
 	margin-top: 6px;
 	opacity: 0.6;
 }


### PR DESCRIPTION
so #site-logo gets correct width in IE therefore img does not overflow.
fixes #131 

Yay, another bug bites the dust!